### PR TITLE
Add explicit close() method to TursoDatabase for reliable sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 - **Zero-config databases** &mdash; Databases are created automatically on first use
 - **Local SQLite** &mdash; Fast reads from a local database copy in the serverless function
-- **Automatic sync** &mdash; Writes are automatically pushed to Turso via Vercel's `waitUntil`
+- **Automatic sync** &mdash; Writes are automatically pushed to Turso when the database connection is closed
 - **Partial sync** &mdash; Sync only the data you need for efficient cold starts
 
 ## Install
@@ -94,8 +94,6 @@ await db.execute(
   ["Alice", "alice@example.com"]
 );
 
-// Changes sync automatically via waitUntil - no manual push needed!
-
 // Query data
 const result = await db.query("SELECT * FROM users");
 console.log(result.rows);
@@ -141,11 +139,11 @@ await db.execute(
 
 ### `db.push()`
 
-Manually push local changes to the remote Turso database. This is optional since changes are automatically synced via Vercel's `waitUntil`, but useful when you need to ensure data is synced before responding.
+Manually push local changes to the remote Turso database.
 
 ```ts
 await db.execute("INSERT INTO users (name) VALUES (?)", ["Charlie"]);
-await db.push(); // Explicit sync (optional - auto-sync happens via waitUntil)
+await db.push();
 ```
 
 ### `db.pull()`

--- a/examples/guestbook/package-lock.json
+++ b/examples/guestbook/package-lock.json
@@ -8,7 +8,7 @@
       "name": "turso-vercel-example",
       "version": "0.1.0",
       "dependencies": {
-        "@tursodatabase/vercel-experimental": "^0.0.3",
+        "@tursodatabase/vercel-experimental": "../..",
         "@vercel/functions": "^1.0.0",
         "next": "^14.0.0",
         "react": "^18.0.0",
@@ -22,12 +22,12 @@
     },
     "../..": {
       "name": "@tursodatabase/vercel-experimental",
-      "version": "0.0.1",
-      "extraneous": true,
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "@tursodatabase/api": "^1.9.0",
-        "@tursodatabase/sync": "^0.5.0-pre.5"
+        "@tursodatabase/sync": "^0.5.0-pre.5",
+        "@vercel/functions": "^1.0.0"
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
@@ -35,14 +35,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@vercel/functions": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@vercel/functions": {
-          "optional": true
-        }
       }
     },
     "node_modules/@next/env": {
@@ -211,111 +203,9 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@tursodatabase/api": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/api/-/api-1.9.2.tgz",
-      "integrity": "sha512-CPu4o9m9pCpztgAZm17dMbmLuEJR2HOkBHvGjjt+40C+w3ncoxnZTJsv9gxv47OQhilSjXH1ck/xEMIZpXzRxA==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-fetch": "^3.6.19"
-      }
-    },
-    "node_modules/@tursodatabase/database-common": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/database-common/-/database-common-0.5.0-pre.6.tgz",
-      "integrity": "sha512-zZOGBwxxUM/vjEmGmGDU8ISMOTBfaZbOHqLw5qkdtX+6km+PBE/GqsMqo+RYpaJIlN390pyAyOhEvSkBb15h7Q==",
-      "license": "MIT"
-    },
-    "node_modules/@tursodatabase/sync": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync/-/sync-0.5.0-pre.6.tgz",
-      "integrity": "sha512-QUtNJnHCkZsMlnrBPNx+dA4eWY6VjxsnGWMUQyJ9Blg3UQXqLiML6gJW091VogNM8Nzp7qPpuwNoooQ7w1FPRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tursodatabase/database-common": "^0.5.0-pre.6",
-        "@tursodatabase/sync-common": "^0.5.0-pre.6"
-      },
-      "optionalDependencies": {
-        "@tursodatabase/sync-darwin-arm64": "0.5.0-pre.6",
-        "@tursodatabase/sync-linux-arm64-gnu": "0.5.0-pre.6",
-        "@tursodatabase/sync-linux-x64-gnu": "0.5.0-pre.6",
-        "@tursodatabase/sync-win32-x64-msvc": "0.5.0-pre.6"
-      }
-    },
-    "node_modules/@tursodatabase/sync-common": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync-common/-/sync-common-0.5.0-pre.6.tgz",
-      "integrity": "sha512-iHTr2RfEGkM3apu92nkoXK3xMh4FOXEw+wU+PA7tHLipbR9KSDrdoTK3EUAR7bOgYF6Yj597vXyMtKZ/HPI0lA==",
-      "license": "MIT",
-      "dependencies": {
-        "@tursodatabase/database-common": "^0.5.0-pre.6"
-      }
-    },
-    "node_modules/@tursodatabase/sync-darwin-arm64": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync-darwin-arm64/-/sync-darwin-arm64-0.5.0-pre.6.tgz",
-      "integrity": "sha512-3Y39b0E3fe1/GDBUY2c9nuc964g4OjmPWHLlgklLI5v8zTIvZqGx5VOYystaJmjXMGVmkgFjGKepI8XcKWKJzA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@tursodatabase/sync-linux-arm64-gnu": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync-linux-arm64-gnu/-/sync-linux-arm64-gnu-0.5.0-pre.6.tgz",
-      "integrity": "sha512-ZF6n/7QUrbGQWDOXVt9Xiw09U5OGFZrOI+vr6xnvEGur/BEcsCcDoZbrXzKd/MZmbpJWCWcIcmidCauAYOg6tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@tursodatabase/sync-linux-x64-gnu": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync-linux-x64-gnu/-/sync-linux-x64-gnu-0.5.0-pre.6.tgz",
-      "integrity": "sha512-YGWAGZKK+HNGOJ8hb7Jq1wKyXTNXYuBS6Q7GRK76hhS+0TvJwQShplucXhtb/qrKoYK6DRbGkuGpeoWdExeNXw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@tursodatabase/sync-win32-x64-msvc": {
-      "version": "0.5.0-pre.6",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/sync-win32-x64-msvc/-/sync-win32-x64-msvc-0.5.0-pre.6.tgz",
-      "integrity": "sha512-i9On7O3mzZj/DfGzDoxE/GFHntLGnOer23h13yomeUfv9uHebS7YFslvdD8YVhxeQoRQiNqXQiBblGVPuMb1tw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@tursodatabase/vercel-experimental": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@tursodatabase/vercel-experimental/-/vercel-experimental-0.0.3.tgz",
-      "integrity": "sha512-Zo5vDQvhDbD6e0pTkUxo5ntjzCOfvH5MGBe7684ldOoKszbDFSV8N9juN6LcjO0z7LcQasMK3FMGudgw3kaFDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@tursodatabase/api": "^1.9.0",
-        "@tursodatabase/sync": "^0.5.0-pre.5",
-        "@vercel/functions": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
+      "resolved": "../..",
+      "link": true
     },
     "node_modules/@types/node": {
       "version": "20.19.31",
@@ -633,12 +523,6 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/whatwg-fetch": {
-      "version": "3.6.20",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
-      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
     }
   }

--- a/examples/guestbook/package.json
+++ b/examples/guestbook/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@tursodatabase/vercel-experimental": "^0.0.3",
+    "@tursodatabase/vercel-experimental": "../..",
     "@vercel/functions": "^1.0.0",
     "next": "^14.0.0",
     "react": "^18.0.0",


### PR DESCRIPTION
close() pushes dirty writes and closes the underlying database, propagating errors to the caller. The waitUntil-based scheduleFlush now acts as a safety net that warns and closes databases the user forgot to close, rather than being the primary sync path. Examples updated to use try/finally with db.close().